### PR TITLE
Fix/flush tracks

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/optimizelyx/OptimizelyXIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/optimizelyx/OptimizelyXIntegration.java
@@ -110,8 +110,7 @@ public class OptimizelyXIntegration extends Integration<Void> {
     synchronized (this) {
       if (!client.isValid()) {
         logger.verbose("Optimizely not initialized. Enqueueing action: %s", track);
-        int queueSize = trackEvents.size();
-        if (queueSize >= 100) {
+        if (trackEvents.size() >= 100) {
           logger.verbose(
               "Event queue has exceeded limit. Dropping event at index zero: %s",
               trackEvents.get(0));

--- a/src/main/java/com/segment/analytics/android/integrations/optimizelyx/OptimizelyXIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/optimizelyx/OptimizelyXIntegration.java
@@ -107,11 +107,10 @@ public class OptimizelyXIntegration extends Integration<Void> {
   public void track(TrackPayload track) {
     super.track(track);
 
-    int queueSize = trackEvents.size();
-
     synchronized (this) {
       if (!client.isValid()) {
         logger.verbose("Optimizely not initialized. Enqueueing action: %s", track);
+        int queueSize = trackEvents.size();
         if (queueSize >= 100) {
           logger.verbose(
               "Event queue has exceeded limit. Dropping event at index zero: %s",


### PR DESCRIPTION
Moves trackEvents.size() method call within the conditional blocking checking the validity of the Optimizely client. Because `trackEvents` is set to null after flush, apps would crash next time `track` was invoked because `size()` was called on a null object reference.