### PR TITLE
Bump Optimizely X dep to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,15 +34,14 @@ dependencies {
     mavenCentral()
   }
 
-  compile 'com.optimizely.ab:android-sdk:1.4.0'
-
   compile 'com.segment.analytics.android:analytics:4.0.0'
+  testCompile 'com.segment.analytics.android:analytics-tests:4.0.0'
+
+  compile 'com.optimizely.ab:android-sdk:1.5.1'
 
   testCompile 'junit:junit:4.12'
 
   testCompile 'org.robolectric:robolectric:3.4.2'
-
-  testCompile 'com.segment.analytics.android:analytics-tests:4.0.0'
 
   testCompile 'org.assertj:assertj-core:1.7.1'
 


### PR DESCRIPTION
Bumps Optimizely X dependency to v1.5.1. 

*New Features*
- Numeric metrics
- Client-side programmatic forced variations.

*Bug Fixes*
- Remove Espresso dependency
- Narrow proguard rules
- Last modified fixed so that multiple project files can be used.
-Call start listener if there is an exception.
- Example of overriding Gson and android-logger in test-app gradle file.
- Fix crash on API 17 (missing annotation).
- Support for Android O (please see developer docs for details). Basically, Android O and above will use JobScheduler and pre Android O will continue to use AlarmService. This is done through a class called the JobWorkService which allows you to keep your Service and IntentService intact. Developers can piggyback on this method and keep thier IntentServices and use the JobWorkService.